### PR TITLE
Button/theme fix

### DIFF
--- a/src/components/Button/Button.styled.tsx
+++ b/src/components/Button/Button.styled.tsx
@@ -7,16 +7,16 @@ export const Button = styled.button<ButtonProps>`
 	border-radius: 5px;
 	width: 141px;
 	height: 48px;
-	background-color: ${({ theme }) => theme.color.violet};
+	background-color: ${({ theme }) => theme.themeColor};
 	cursor: pointer;
 	font-weight: 700;
 	font-size: 16px;
 	line-height: 20px;
 	text-align: center;
-	color: ${({ theme }) => theme.color.white};
+	color: ${({ theme }) => theme.basicColor};
 	transition: background-color 0.1s ease-in;
 	&:hover {
-		background-color: ${({ theme }) => theme.color.lightViolet};
+		background-color: ${({ theme }) => theme.themeSecondColor};
 	}
 `;
 
@@ -24,10 +24,10 @@ export const StyledButton = styled(Button)`
 	${({ variant }) => {
 		if (variant === 'second')
 			return css`
-				color: ${({ theme }) => theme.mode.buttonSecondText};
-				background-color: ${({ theme }) => theme.mode.buttonSecond};
+				color: ${({ theme }) => theme.buttonSecondText};
+				background-color: ${({ theme }) => theme.buttonSecond};
 				&:hover {
-					background-color: ${({ theme }) => theme.mode.buttonSecondHover};
+					background-color: ${({ theme }) => theme.buttonSecondHover};
 				}
 			`;
 	}}

--- a/src/components/Button/Button.styled.tsx
+++ b/src/components/Button/Button.styled.tsx
@@ -1,0 +1,34 @@
+import { css } from 'styled-components';
+import styled from 'styled-components';
+import { ButtonProps } from '../../types/types';
+
+export const Button = styled.button<ButtonProps>`
+	border: none;
+	border-radius: 5px;
+	width: 141px;
+	height: 48px;
+	background-color: ${({ theme }) => theme.color.violet};
+	cursor: pointer;
+	font-weight: 700;
+	font-size: 16px;
+	line-height: 20px;
+	text-align: center;
+	color: ${({ theme }) => theme.color.white};
+	transition: background-color 0.1s ease-in;
+	&:hover {
+		background-color: ${({ theme }) => theme.color.lightViolet};
+	}
+`;
+
+export const StyledButton = styled(Button)`
+	${({ variant }) => {
+		if (variant === 'second')
+			return css`
+				color: ${({ theme }) => theme.mode.buttonSecondText};
+				background-color: ${({ theme }) => theme.mode.buttonSecond};
+				&:hover {
+					background-color: ${({ theme }) => theme.mode.buttonSecondHover};
+				}
+			`;
+	}}
+`;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,11 @@
+import { StyledButton } from './Button.styled';
+import { ButtonProps } from '../../types/types';
+
+const Button = ({ children, variant, onClick }: ButtonProps) => {
+	return (
+		<StyledButton onClick={onClick} variant={variant}>
+			{children}
+		</StyledButton>
+	);
+};
+export default Button;

--- a/src/components/Header/DarkModeToggle/DarkModeToggle.styled.tsx
+++ b/src/components/Header/DarkModeToggle/DarkModeToggle.styled.tsx
@@ -1,46 +1,46 @@
 import styled from 'styled-components';
 
 export const StyledDarkModeToggle = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 7rem;
-  height: 1.5rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 7rem;
+	height: 1.5rem;
 `;
 
 export const StyledDarkModeButton = styled.button`
-  display: flex;
-  align-items: center;
-  width: 48px;
-  height: 24px;
-  outline: none;
-  border: none;
-  border-radius: 12px;
-  background-color: ${({ theme }) => theme.color.white};
-  cursor: pointer;
-  &:hover {
-    div {
-      background-color: ${({ theme }) => theme.color.lightViolet};
-    }
-  }
+	display: flex;
+	align-items: center;
+	width: 48px;
+	height: 24px;
+	outline: none;
+	border: none;
+	border-radius: 12px;
+	background-color: ${({ theme }) => theme.basicColor};
+	cursor: pointer;
+	&:hover {
+		div {
+			background-color: ${({ theme }) => theme.themeSecondColor};
+		}
+	}
 `;
 
 export const StyledDarkModeButtonDot = styled.div`
-  transition: all 0.3s;
-  width: 14px;
-  height: 14px;
-  border-radius: 100%;
-  background-color: ${({ theme }) => theme.color.violet};
-  transform: ${({ theme }) =>
-    theme.themeMode === 'darkMode' ? 'translateX(22px)' : 'translateX(0)'};
+	transition: all 0.3s;
+	width: 14px;
+	height: 14px;
+	border-radius: 100%;
+	background-color: ${({ theme }) => theme.themeColor};
+	transform: ${({ theme }) =>
+		theme.themeMode === 'darkMode' ? 'translateX(22px)' : 'translateX(0)'};
 `;
 
 export const StyledSunIcon = styled.img`
-  height: 20px;
-  width: 20px;
+	height: 20px;
+	width: 20px;
 `;
 
 export const StyledMoonIcon = styled.img`
-  height: 12px;
-  width: 12px;
+	height: 12px;
+	width: 12px;
 `;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,24 +1,29 @@
 import {
-  StyledHeader,
-  StyledHeaderContainer,
-  StyledLogo,
+	StyledHeader,
+	StyledHeaderContainer,
+	StyledLogo,
 } from './Header.styled';
 import logo from '../../assets/desktop/logo.svg';
 import DarkModeToggle from './DarkModeToggle/DarkModeToggle';
-
+import Button from '../Button/Button';
 interface Props {
-  darkModeHandler: () => void;
+	darkModeHandler: () => void;
 }
 
 const Header = ({ darkModeHandler }: Props) => {
-  return (
-    <StyledHeader>
-      <StyledHeaderContainer>
-        <StyledLogo src={logo}></StyledLogo>
-        <DarkModeToggle darkModeHandler={darkModeHandler}></DarkModeToggle>
-      </StyledHeaderContainer>
-    </StyledHeader>
-  );
+	return (
+		<>
+			<StyledHeader>
+				<StyledHeaderContainer>
+					<StyledLogo src={logo}></StyledLogo>
+					<DarkModeToggle darkModeHandler={darkModeHandler}></DarkModeToggle>
+				</StyledHeaderContainer>
+			</StyledHeader>
+			{/* Testing Button  */}
+			<Button onClick={() => console.log('hello')}>Button 1</Button>
+			<Button variant='second'>Button 2</Button>
+		</>
+	);
 };
 
 export default Header;

--- a/src/components/hooks/useDarkMode.tsx
+++ b/src/components/hooks/useDarkMode.tsx
@@ -1,28 +1,32 @@
 import { useState } from 'react';
-
 import { ThemeType } from '../../App';
 
 interface NewThemeType extends ThemeType {
-  mode: { [key: string]: string };
-  themeMode: 'lightMode' | 'darkMode';
+	themeMode: string;
 }
 
 const useDarkMode = (theme: ThemeType): [NewThemeType, () => void] => {
-  const [themeMode, setThemeMode] = useState<'lightMode' | 'darkMode'>(
-    'lightMode'
-  );
+	const [themeMode, setThemeMode] = useState<'lightMode' | 'darkMode'>(
+		'lightMode'
+	);
 
-  const darkModeHandler = () => {
-    if (themeMode === 'lightMode') {
-      setThemeMode('darkMode');
-    } else {
-      setThemeMode('lightMode');
-    }
-  };
+	const darkModeHandler = () => {
+		if (themeMode === 'lightMode') {
+			setThemeMode('darkMode');
+		} else {
+			setThemeMode('lightMode');
+		}
+	};
 
-  let newTheme = { ...theme, mode: { ...theme[themeMode] }, themeMode };
+	const getNewTheme = () => {
+		if (themeMode === 'lightMode') {
+			return theme;
+		} else themeMode === 'darkMode';
+		return { ...theme, ...theme.darkMode, themeMode };
+	};
 
-  return [newTheme, darkModeHandler];
+	const newTheme = getNewTheme();
+	return [newTheme, darkModeHandler];
 };
 
 export default useDarkMode;

--- a/src/global.css.ts
+++ b/src/global.css.ts
@@ -54,6 +54,6 @@ table {
     font-size: 16px;
     line-height: 26px;
     height:100vh;
-	background-color: ${props => props.theme.mode.mainBackground};
+	background-color: ${props => props.theme.mainBackground};
   }
 `;

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -1,42 +1,48 @@
 export const theme = {
-  color: {
-    violet: '#5964e0',
-    lightViolet: '#939BF4',
-    veryDarkBlue: '#19202D',
-    midnight: '#121721',
-    white: '#FFFFFF',
-    lightGrey: '#F4F6F8',
-    gray: ' #9DAEC2',
-    darkGrey: '#6E8098',
-  },
-  darkMode: {
-    mainBackground: '#121721',
-    boxBackground: '#19202D',
-    headingText: '#fff',
-    regularText: '#6E8098',
-  },
-  lightMode: {
-    mainBackground: '#F4F6F8',
-    boxBackground: '#fff',
-    headingText: '#19202D',
-    regularText: '#9DAEC2',
-  },
-  textHeading: {
-    h1: `
+	color: {
+		violet: '#5964e0',
+		lightViolet: '#939BF4',
+		veryDarkBlue: '#19202D',
+		midnight: '#121721',
+		white: '#FFFFFF',
+		lightGrey: '#F4F6F8',
+		gray: ' #9DAEC2',
+		darkGrey: '#6E8098',
+	},
+	darkMode: {
+		mainBackground: '#121721',
+		boxBackground: '#19202D',
+		headingText: '#FFFFFF',
+		regularText: '#6E8098',
+		buttonSecond: '#303642',
+		buttonSecondText: '#FFFFFF',
+		buttonSecondHover: '#696e76',
+	},
+	lightMode: {
+		mainBackground: '#F4F6F8',
+		boxBackground: '#FFFFFF',
+		headingText: '#19202D',
+		regularText: '#9DAEC2',
+		buttonSecond: '#eff0fc',
+		buttonSecondText: '#5964E0',
+		buttonSecondHover: '#c5c9f4',
+	},
+	textHeading: {
+		h1: `
     font-weight: 700;
     font-size: 28px;
     line-height: 35px;`,
-    h2: `
+		h2: `
     font-weight: 700;
     font-size: 24px;
     line-height: 30px;`,
-    h3: `
+		h3: `
     font-weight: 700;
     font-size: 24px;
     line-height: 30px;`,
-    h4: `
+		h4: `
         font-weight: 700;
         font-size: 14px;
         line-height: 17px;`,
-  },
+	},
 };

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -1,32 +1,42 @@
+const color = {
+	violet: '#5964e0',
+	lightViolet: '#939BF4',
+	veryDarkBlue: '#19202D',
+	midnight: '#121721',
+	white: '#FFFFFF',
+	lightGrey: '#F4F6F8',
+	dirtyWhite: '#eff0fc',
+	dirtyViolet: '#c5c9f4',
+	gray: ' #9DAEC2',
+	mediumGray: '#303642',
+	lightmGray: '#696e76',
+	darkGray: '#6E8098',
+};
+
 export const theme = {
-	color: {
-		violet: '#5964e0',
-		lightViolet: '#939BF4',
-		veryDarkBlue: '#19202D',
-		midnight: '#121721',
-		white: '#FFFFFF',
-		lightGrey: '#F4F6F8',
-		gray: ' #9DAEC2',
-		darkGrey: '#6E8098',
-	},
+	basicColor: color.white,
+	themeColor: color.violet,
+	themeSecondColor: color.lightViolet,
+	mainBackground: color.white,
+	boxBackground: color.white,
+	headingText: color.veryDarkBlue,
+	regularText: color.gray,
+	buttonSecond: color.dirtyWhite,
+	buttonSecondText: color.violet,
+	buttonSecondHover: color.dirtyViolet,
+	themeMode: 'lightMode',
+
 	darkMode: {
-		mainBackground: '#121721',
-		boxBackground: '#19202D',
-		headingText: '#FFFFFF',
-		regularText: '#6E8098',
-		buttonSecond: '#303642',
-		buttonSecondText: '#FFFFFF',
-		buttonSecondHover: '#696e76',
+		mainBackground: color.midnight,
+		boxBackground: color.veryDarkBlue,
+		headingText: color.white,
+		regularText: color.darkGray,
+		buttonSecond: color.mediumGray,
+		buttonSecondHover: color.lightGrey,
+		buttonSecondText: color.white,
+		themeMode: 'darkMode',
 	},
-	lightMode: {
-		mainBackground: '#F4F6F8',
-		boxBackground: '#FFFFFF',
-		headingText: '#19202D',
-		regularText: '#9DAEC2',
-		buttonSecond: '#eff0fc',
-		buttonSecondText: '#5964E0',
-		buttonSecondHover: '#c5c9f4',
-	},
+
 	textHeading: {
 		h1: `
     font-weight: 700;

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -1,0 +1,5 @@
+export type ButtonProps = {
+	onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+	children?: React.ReactNode;
+	variant?: 'second';
+};


### PR DESCRIPTION
**Added Button with variant.** 
**Primary** (default) and **second** (to use this variant add props with string _second_) 


**I have modified theme.** 
Now theme is cleaner (I guess :D) and we dont need to use mode (props.theme.mode.color) . All props from theme is shorter. 
To add new property (for example new color to new component) add new key in theme. If element have dark mode add one in darkMode. 
Why color is separately? 
I think is much cleaner and expandable. If you modify  for example color you keep integrity of design. Also you can change color for crushal element in one file. 